### PR TITLE
os/signal.NotifyContext requires at least go 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/int128/kubectl-socat
 
-go 1.15
+go 1.16
 
 require (
 	github.com/cenkalti/backoff/v4 v4.1.0


### PR DESCRIPTION
https://pkg.go.dev/os/signal@go1.15.8#pkg-functions